### PR TITLE
[Ashwini] adds signwithApple

### DIFF
--- a/SignInAppUsingFireBase.xcodeproj/project.pbxproj
+++ b/SignInAppUsingFireBase.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		330B6119264038AF00FEE667 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 330B6118264038AF00FEE667 /* GoogleService-Info.plist */; };
 		334AD33B2643F04A00F4E1B0 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334AD33A2643F04A00F4E1B0 /* SignUpViewController.swift */; };
 		33698F6F2645455B00AFF55A /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33698F6E2645455B00AFF55A /* HomeViewController.swift */; };
+		336E93BE264A5DD100B93962 /* SignInWithAppple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336E93BD264A5DD100B93962 /* SignInWithAppple.swift */; };
 		637F517D4B560830090CFF49 /* Pods_SignInAppUsingFireBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8E28526FC9F255A059A47DD /* Pods_SignInAppUsingFireBase.framework */; };
 /* End PBXBuildFile section */
 
@@ -32,6 +33,8 @@
 		330B6118264038AF00FEE667 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		334AD33A2643F04A00F4E1B0 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		33698F6E2645455B00AFF55A /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		336E93BB264A5D5100B93962 /* SignInAppUsingFireBase.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SignInAppUsingFireBase.entitlements; sourceTree = "<group>"; };
+		336E93BD264A5DD100B93962 /* SignInWithAppple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppple.swift; sourceTree = "<group>"; };
 		81959F0F339AE3F6072F58B3 /* Pods-SignInAppUsingFireBase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignInAppUsingFireBase.release.xcconfig"; path = "Target Support Files/Pods-SignInAppUsingFireBase/Pods-SignInAppUsingFireBase.release.xcconfig"; sourceTree = "<group>"; };
 		C8E28526FC9F255A059A47DD /* Pods_SignInAppUsingFireBase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SignInAppUsingFireBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -69,9 +72,11 @@
 		330B60F2264003A000FEE667 /* SignInAppUsingFireBase */ = {
 			isa = PBXGroup;
 			children = (
+				336E93BB264A5D5100B93962 /* SignInAppUsingFireBase.entitlements */,
 				330B60F3264003A000FEE667 /* AppDelegate.swift */,
 				330B60F5264003A000FEE667 /* SceneDelegate.swift */,
 				330B60F7264003A000FEE667 /* LoginViewController.swift */,
+				336E93BD264A5DD100B93962 /* SignInWithAppple.swift */,
 				334AD33A2643F04A00F4E1B0 /* SignUpViewController.swift */,
 				33698F6E2645455B00AFF55A /* HomeViewController.swift */,
 				330B60F9264003A000FEE667 /* Main.storyboard */,
@@ -218,6 +223,7 @@
 				330B60F8264003A000FEE667 /* LoginViewController.swift in Sources */,
 				330B60F4264003A000FEE667 /* AppDelegate.swift in Sources */,
 				33698F6F2645455B00AFF55A /* HomeViewController.swift in Sources */,
+				336E93BE264A5DD100B93962 /* SignInWithAppple.swift in Sources */,
 				334AD33B2643F04A00F4E1B0 /* SignUpViewController.swift in Sources */,
 				330B60F6264003A000FEE667 /* SceneDelegate.swift in Sources */,
 			);
@@ -367,6 +373,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SignInAppUsingFireBase/SignInAppUsingFireBase.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = NU6X2YT7QZ;
 				INFOPLIST_FILE = SignInAppUsingFireBase/Info.plist;
@@ -387,6 +394,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SignInAppUsingFireBase/SignInAppUsingFireBase.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = NU6X2YT7QZ;
 				INFOPLIST_FILE = SignInAppUsingFireBase/Info.plist;

--- a/SignInAppUsingFireBase/AppDelegate.swift
+++ b/SignInAppUsingFireBase/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
+        if let user = Auth.auth().currentUser {
+            print("You're sign in as \(user.uid), email:\(user.email ?? "")")
+        }
         return true
     }
 

--- a/SignInAppUsingFireBase/SceneDelegate.swift
+++ b/SignInAppUsingFireBase/SceneDelegate.swift
@@ -16,6 +16,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        
+        let viewController = SignInWithApple()
+        self.window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 

--- a/SignInAppUsingFireBase/SignInAppUsingFireBase.entitlements
+++ b/SignInAppUsingFireBase/SignInAppUsingFireBase.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/SignInAppUsingFireBase/SignInWithAppple.swift
+++ b/SignInAppUsingFireBase/SignInWithAppple.swift
@@ -1,0 +1,146 @@
+//
+//  SignInWithAppple.swift
+//  SignInAppUsingFireBase
+//
+//  Created by Ashwini shalke on 11/05/21.
+//
+
+import UIKit
+import AuthenticationServices
+import FirebaseAuth
+
+
+class SignInWithApple: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupSignInButton()
+    }
+    
+    func setupSignInButton(){
+        let button = ASAuthorizationAppleIDButton()
+        button.addTarget(self, action: #selector(handleSignInWithAppleTapped), for: .touchUpInside)
+        button.center = view.center
+        view.addSubview(button)
+    }
+    
+    @objc func handleSignInWithAppleTapped(){
+        performSignIn()
+    }
+    
+    func performSignIn(){
+        let request = createAppleIDRequest()
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+    
+    func createAppleIDRequest() -> ASAuthorizationAppleIDRequest {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let nonce = randomNonceString()
+        request.nonce = sha256(nonce)
+        currentNonce = nonce
+        return request
+    }
+}
+
+extension SignInWithApple: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            // Initialize a Firebase credential.
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                      idToken: idTokenString,
+                                                      rawNonce: nonce)
+            // Sign in with Firebase.
+            Auth.auth().signIn(with: credential) { (authResult, error) in
+                if (error != nil) {
+                    // Error. If error.code == .MissingOrInvalidNonce, make sure
+                    // you're sending the SHA256-hashed nonce as a hex string with
+                    // your request to Apple.
+                    print(error?.localizedDescription ?? "")
+                    return
+                }
+                // User is signed in to Firebase with Apple.
+                // ...
+                let homeView = HomeViewController()
+                homeView.modalPresentationStyle = .fullScreen
+                self.present(homeView, animated: true, completion: nil)
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // Handle error.
+        print("Sign in with Apple errored: \(error)")
+    }
+}
+
+extension SignInWithApple: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+}
+
+private func randomNonceString(length: Int = 32) -> String {
+    precondition(length > 0)
+    let charset: Array<Character> =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+    var result = ""
+    var remainingLength = length
+    
+    while remainingLength > 0 {
+        let randoms: [UInt8] = (0 ..< 16).map { _ in
+            var random: UInt8 = 0
+            let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+            if errorCode != errSecSuccess {
+                fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+            }
+            return random
+        }
+        
+        randoms.forEach { random in
+            if remainingLength == 0 {
+                return
+            }
+            
+            if random < charset.count {
+                result.append(charset[Int(random)])
+                remainingLength -= 1
+            }
+        }
+    }
+    return result
+}
+
+import CryptoKit
+// Unhashed nonce.
+fileprivate var currentNonce: String?
+
+@available(iOS 13, *)
+private func sha256(_ input: String) -> String {
+    let inputData = Data(input.utf8)
+    let hashedData = SHA256.hash(data: inputData)
+    let hashString = hashedData.compactMap {
+        return String(format: "%02x", $0)
+    }.joined()
+    
+    return hashString
+}
+
+
+


### PR DESCRIPTION
###Sign in with Apple and authenticate with Firebase

1. Configure Sign In with Apple.
2. For every sign-in request, generate a random string—a "nonce".
3. Start Apple's sign-in flow, including in your request the SHA256 hash of the nonce.
4. Handle Apple's response in your implementation of ASAuthorizationControllerDelegate.

For more detail refer - https://firebase.google.com/docs/auth/ios/apple?authuser=0